### PR TITLE
Missing build dependency

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine
+        pip install setuptools wheel twine build
     - name: Build and publish
       env:
         TWINE_USERNAME: __token__


### PR DESCRIPTION
We require `build` to push into pypi