### PR TITLE
Add documentation for reading a single price account

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,24 @@ PythPriceType.PRICE 4.23125 p/m 0.0019500000000000001
 ...
 ```
 
+You can also read the current price of a specific price feed if you know its account key:
+
+```
+from pythclient.pythaccounts import PythPriceAccount
+from pythclient.solana import SolanaClient, SolanaPublicKey, SOLANA_DEVNET_HTTP_ENDPOINT, SOLANA_DEVNET_WS_ENDPOINT
+
+# devnet DOGE/USD price account key (available on pyth.network website)
+account_key = SolanaPublicKey("4L6YhY8VvUgmqG5MvJkUJATtzB2rFqdrJwQCmFLv4Jzy")
+solana_client = SolanaClient(endpoint=SOLANA_DEVNET_HTTP_ENDPOINT, ws_endpoint=SOLANA_DEVNET_WS_ENDPOINT)
+price: PythPriceAccount = PythPriceAccount(account_key, solana_client)
+
+# Fetch most recent account data from on-chain
+await price.update()
+
+# Sample output: "DOGE/USD is 0.141455 ± 7.4e-05"
+print("DOGE/USD is", price.aggregate_price, "±", price.aggregate_price_confidence_interval)
+```
+
 The library also includes an asynchronous API that updates the prices using a websocket subscription or account polling.
 See `examples/dump.py` for a more detailed usage example.
 

--- a/README.md
+++ b/README.md
@@ -52,26 +52,9 @@ PythPriceType.PRICE 4.23125 p/m 0.0019500000000000001
 ...
 ```
 
-You can also read the current price of a specific price feed if you know its account key:
-
-```
-from pythclient.pythaccounts import PythPriceAccount
-from pythclient.solana import SolanaClient, SolanaPublicKey, SOLANA_DEVNET_HTTP_ENDPOINT, SOLANA_DEVNET_WS_ENDPOINT
-
-# devnet DOGE/USD price account key (available on pyth.network website)
-account_key = SolanaPublicKey("4L6YhY8VvUgmqG5MvJkUJATtzB2rFqdrJwQCmFLv4Jzy")
-solana_client = SolanaClient(endpoint=SOLANA_DEVNET_HTTP_ENDPOINT, ws_endpoint=SOLANA_DEVNET_WS_ENDPOINT)
-price: PythPriceAccount = PythPriceAccount(account_key, solana_client)
-
-# Fetch most recent account data from on-chain
-await price.update()
-
-# Sample output: "DOGE/USD is 0.141455 ± 7.4e-05"
-print("DOGE/USD is", price.aggregate_price, "±", price.aggregate_price_confidence_interval)
-```
-
-The library also includes an asynchronous API that updates the prices using a websocket subscription or account polling.
-See `examples/dump.py` for a more detailed usage example.
+The `examples` directory includes some example applications that demonstrate how to use this library:
+* `examples/dump.py` is a detailed usage example that demonstrates the asynchronous API to update prices using a websocket subscription or account polling.
+* `examples/read_one_price_feed.py` shows how to read the price of a single price feed using its account key.
 
 Developer Setup
 ---------------

--- a/examples/read_one_price_feed.py
+++ b/examples/read_one_price_feed.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+
+import asyncio
+
+from pythclient.pythaccounts import PythPriceAccount
+from pythclient.solana import SolanaClient, SolanaPublicKey, SOLANA_DEVNET_HTTP_ENDPOINT, SOLANA_DEVNET_WS_ENDPOINT
+
+async def get_price():
+    # devnet DOGE/USD price account key (available on pyth.network website)
+    account_key = SolanaPublicKey("4L6YhY8VvUgmqG5MvJkUJATtzB2rFqdrJwQCmFLv4Jzy")
+    solana_client = SolanaClient(endpoint=SOLANA_DEVNET_HTTP_ENDPOINT, ws_endpoint=SOLANA_DEVNET_WS_ENDPOINT)
+    price: PythPriceAccount = PythPriceAccount(account_key, solana_client)
+
+    await price.update()
+    # Sample output: "DOGE/USD is 0.141455 ± 7.4e-05"
+    print("DOGE/USD is", price.aggregate_price, "±", price.aggregate_price_confidence_interval)
+
+asyncio.run(get_price())


### PR DESCRIPTION
We've gotten a couple of questions about how to read the value of a single price feed. Add to docs for future reference.

I tested the code in a local interactive python session.