### PR TITLE
update dump.py to clarify PythClient args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,6 +113,7 @@ celerybeat.pid
 .venv
 env/
 venv/
+ve/
 ENV/
 env.bak/
 venv.bak/

--- a/examples/dump.py
+++ b/examples/dump.py
@@ -34,8 +34,8 @@ signal.signal(signal.SIGINT, set_to_exit)
 async def main():
     global to_exit
     use_program = len(sys.argv) >= 2 and sys.argv[1] == "program"
-    v2_first_mapping_account_key = get_key("mainnet", "mapping")
-    v2_program_key = get_key("mainnet", "program")
+    v2_first_mapping_account_key = get_key("devnet", "mapping")
+    v2_program_key = get_key("devnet", "program")
     async with PythClient(
         first_mapping_account_key=v2_first_mapping_account_key,
         program_key=v2_program_key if use_program else None,

--- a/examples/dump.py
+++ b/examples/dump.py
@@ -8,6 +8,7 @@ import sys
 from typing import List, Any
 
 from loguru import logger
+from pythclient.solana import SOLANA_DEVNET_HTTP_ENDPOINT, SOLANA_DEVNET_WS_ENDPOINT
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from pythclient.pythclient import PythClient  # noqa
@@ -33,11 +34,13 @@ signal.signal(signal.SIGINT, set_to_exit)
 async def main():
     global to_exit
     use_program = len(sys.argv) >= 2 and sys.argv[1] == "program"
-    v2_first_mapping_account_key = get_key("devnet", "mapping")
-    v2_program_key = get_key("devnet", "program")
+    v2_first_mapping_account_key = get_key("mainnet", "mapping")
+    v2_program_key = get_key("mainnet", "program")
     async with PythClient(
         first_mapping_account_key=v2_first_mapping_account_key,
         program_key=v2_program_key if use_program else None,
+        solana_endpoint=SOLANA_DEVNET_HTTP_ENDPOINT, # replace with the relevant cluster endpoints
+        solana_ws_endpoint=SOLANA_DEVNET_WS_ENDPOINT # replace with the relevant cluster endpoints
     ) as c:
         await c.refresh_all_prices()
         products = await c.get_products()

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-requirements = ['aiodns', 'aiohttp>=3.7.4', 'backoff', 'base58', 'dnspython', 'flake8', 'loguru']
+requirements = ['aiodns', 'aiohttp>=3.7.4', 'backoff', 'base58', 'dnspython', 'flake8', 'loguru', 'typing-extensions']
 
 with open('README.md', 'r', encoding='utf-8') as fh:
     long_description = fh.read()


### PR DESCRIPTION
received a comment from discord where user changed `get_key(devnet)` to `get_key(mainnet)` and program complains that program key is not found -- reason being there are no cluster endpoints passed in to PythClient which uses devnet as default