### PR TITLE
Add get_aggregate_price_status which takes care of becoming stale

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ async with PythClient(
         for _, pr in prices.items():
             print(
                 pr.price_type,
-                await pr.get_aggregate_price_status(),
+                pr.aggregate_price_status,
                 pr.aggregate_price,
                 "p/m",
                 pr.aggregate_price_confidence_interval,
@@ -49,7 +49,7 @@ PythPriceType.PRICE PythPriceStatus.TRADING 4390.286 p/m 2.4331
 {'symbol': 'Crypto.SOL/USD', 'asset_type': 'Crypto', 'quote_currency': 'USD', 'description': 'SOL/USD', 'generic_symbol': 'SOLUSD', 'base': 'SOL'}
 PythPriceType.PRICE PythPriceStatus.TRADING 192.27550000000002 p/m 0.0485
 {'symbol': 'Crypto.SRM/USD', 'asset_type': 'Crypto', 'quote_currency': 'USD', 'description': 'SRM/USD', 'generic_symbol': 'SRMUSD', 'base': 'SRM'}
-PythPriceType.PRICE PythPriceStatus.UNKNOWN 4.23125 p/m 0.0019500000000000001
+PythPriceType.PRICE PythPriceStatus.UNKNOWN None p/m None
 ...
 ```
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Install the library:
 
 You can then read the current Pyth price using the following:
 
-```
+```python
 from pythclient.pythclient import PythClient
 from pythclient.pythaccounts import PythPriceAccount
 from pythclient.utils import get_key
@@ -34,6 +34,7 @@ async with PythClient(
         for _, pr in prices.items():
             print(
                 pr.price_type,
+                await pr.get_aggregate_price_status(),
                 pr.aggregate_price,
                 "p/m",
                 pr.aggregate_price_confidence_interval,
@@ -44,11 +45,11 @@ This code snippet lists the products on pyth and the price for each product. Sam
 
 ```
 {'symbol': 'Crypto.ETH/USD', 'asset_type': 'Crypto', 'quote_currency': 'USD', 'description': 'ETH/USD', 'generic_symbol': 'ETHUSD', 'base': 'ETH'}
-PythPriceType.PRICE 4390.286 p/m 2.4331
+PythPriceType.PRICE PythPriceStatus.TRADING 4390.286 p/m 2.4331
 {'symbol': 'Crypto.SOL/USD', 'asset_type': 'Crypto', 'quote_currency': 'USD', 'description': 'SOL/USD', 'generic_symbol': 'SOLUSD', 'base': 'SOL'}
-PythPriceType.PRICE 192.27550000000002 p/m 0.0485
+PythPriceType.PRICE PythPriceStatus.TRADING 192.27550000000002 p/m 0.0485
 {'symbol': 'Crypto.SRM/USD', 'asset_type': 'Crypto', 'quote_currency': 'USD', 'description': 'SRM/USD', 'generic_symbol': 'SRMUSD', 'base': 'SRM'}
-PythPriceType.PRICE 4.23125 p/m 0.0019500000000000001
+PythPriceType.PRICE PythPriceStatus.UNKNOWN 4.23125 p/m 0.0019500000000000001
 ...
 ```
 

--- a/examples/dump.py
+++ b/examples/dump.py
@@ -13,7 +13,7 @@ from pythclient.solana import SOLANA_DEVNET_HTTP_ENDPOINT, SOLANA_DEVNET_WS_ENDP
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from pythclient.pythclient import PythClient  # noqa
 from pythclient.ratelimit import RateLimit  # noqa
-from pythclient.pythaccounts import PythPriceAccount, PythPriceStatus  # noqa
+from pythclient.pythaccounts import PythPriceAccount  # noqa
 from pythclient.utils import get_key # noqa
 
 logger.enable("pythclient")

--- a/examples/dump.py
+++ b/examples/dump.py
@@ -50,12 +50,11 @@ async def main():
             prices = await p.get_prices()
             for _, pr in prices.items():
                 all_prices.append(pr)
-                price_status: PythPriceStatus = await pr.get_aggregate_price_status()
                 print(
                     pr.key,
                     pr.product_account_key,
                     pr.price_type,
-                    price_status,
+                    pr.aggregate_price_status,
                     pr.aggregate_price,
                     "p/m",
                     pr.aggregate_price_confidence_interval,
@@ -85,11 +84,10 @@ async def main():
                     pr = update_task.result()
                     if isinstance(pr, PythPriceAccount):
                         assert pr.product
-                        price_status: PythPriceStatus = await pr.get_aggregate_price_status()
                         print(
                             pr.product.symbol,
                             pr.price_type,
-                            price_status,
+                            pr.aggregate_price_status,
                             pr.aggregate_price,
                             "p/m",
                             pr.aggregate_price_confidence_interval,

--- a/examples/dump.py
+++ b/examples/dump.py
@@ -13,7 +13,7 @@ from pythclient.solana import SOLANA_DEVNET_HTTP_ENDPOINT, SOLANA_DEVNET_WS_ENDP
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from pythclient.pythclient import PythClient  # noqa
 from pythclient.ratelimit import RateLimit  # noqa
-from pythclient.pythaccounts import PythPriceAccount  # noqa
+from pythclient.pythaccounts import PythPriceAccount, PythPriceStatus  # noqa
 from pythclient.utils import get_key # noqa
 
 logger.enable("pythclient")
@@ -50,10 +50,12 @@ async def main():
             prices = await p.get_prices()
             for _, pr in prices.items():
                 all_prices.append(pr)
+                price_status: PythPriceStatus = await pr.get_aggregate_price_status()
                 print(
                     pr.key,
                     pr.product_account_key,
                     pr.price_type,
+                    price_status,
                     pr.aggregate_price,
                     "p/m",
                     pr.aggregate_price_confidence_interval,
@@ -83,14 +85,16 @@ async def main():
                     pr = update_task.result()
                     if isinstance(pr, PythPriceAccount):
                         assert pr.product
+                        price_status: PythPriceStatus = await pr.get_aggregate_price_status()
                         print(
                             pr.product.symbol,
                             pr.price_type,
+                            price_status,
                             pr.aggregate_price,
                             "p/m",
                             pr.aggregate_price_confidence_interval,
                         )
-                        break
+                    break
 
         print("Unsubscribing...")
         if use_program:

--- a/examples/read_one_price_feed.py
+++ b/examples/read_one_price_feed.py
@@ -14,8 +14,8 @@ async def get_price():
     await price.update()
 
     price_status = price.aggregate_price_status
-    # Sample output: "DOGE/USD is 0.141455 ± 7.4e-05"
     if price_status == PythPriceStatus.TRADING:
+        # Sample output: "DOGE/USD is 0.141455 ± 7.4e-05"
         print("DOGE/USD is", price.aggregate_price, "±", price.aggregate_price_confidence_interval)
     else:
         print("Price is not valid now. Status is", price_status)

--- a/examples/read_one_price_feed.py
+++ b/examples/read_one_price_feed.py
@@ -13,7 +13,7 @@ async def get_price():
 
     await price.update()
 
-    price_status: PythPriceStatus = await price.get_aggregate_price_status()
+    price_status: PythPriceStatus = price.aggregate_price_status
     # Sample output: "DOGE/USD is 0.141455 ± 7.4e-05"
     if price_status == PythPriceStatus.TRADING:
         print("DOGE/USD is", price.aggregate_price, "±", price.aggregate_price_confidence_interval)

--- a/examples/read_one_price_feed.py
+++ b/examples/read_one_price_feed.py
@@ -20,4 +20,6 @@ async def get_price():
     else:
         print("Price is not valid now. Status is", price_status)
 
+    await solana_client.close()
+
 asyncio.run(get_price())

--- a/examples/read_one_price_feed.py
+++ b/examples/read_one_price_feed.py
@@ -2,7 +2,7 @@
 
 import asyncio
 
-from pythclient.pythaccounts import PythPriceAccount
+from pythclient.pythaccounts import PythPriceAccount, PythPriceStatus
 from pythclient.solana import SolanaClient, SolanaPublicKey, SOLANA_DEVNET_HTTP_ENDPOINT, SOLANA_DEVNET_WS_ENDPOINT
 
 async def get_price():
@@ -12,7 +12,12 @@ async def get_price():
     price: PythPriceAccount = PythPriceAccount(account_key, solana_client)
 
     await price.update()
+
+    price_status: PythPriceStatus = await price.get_aggregate_price_status()
     # Sample output: "DOGE/USD is 0.141455 ± 7.4e-05"
-    print("DOGE/USD is", price.aggregate_price, "±", price.aggregate_price_confidence_interval)
+    if price_status == PythPriceStatus.TRADING:
+        print("DOGE/USD is", price.aggregate_price, "±", price.aggregate_price_confidence_interval)
+    else:
+        print("Price is not valid now. Status is", price_status)
 
 asyncio.run(get_price())

--- a/examples/read_one_price_feed.py
+++ b/examples/read_one_price_feed.py
@@ -13,7 +13,7 @@ async def get_price():
 
     await price.update()
 
-    price_status: PythPriceStatus = price.aggregate_price_status
+    price_status = price.aggregate_price_status
     # Sample output: "DOGE/USD is 0.141455 ± 7.4e-05"
     if price_status == PythPriceStatus.TRADING:
         print("DOGE/USD is", price.aggregate_price, "±", price.aggregate_price_confidence_interval)

--- a/pythclient/pythaccounts.py
+++ b/pythclient/pythaccounts.py
@@ -524,14 +524,11 @@ class PythPriceAccount(PythAccount):
         Gets the aggregate price status given a solana slot.
         You might consider using this function with the latest solana slot to make sure the price has not gone stale.
         """
-        if self.aggregate_price_info:
-            if self.aggregate_price_info.price_status == PythPriceStatus.TRADING and \
-                slot - self.aggregate_price_info.pub_slot > MAX_SLOT_DIFFERENCE:
-                return PythPriceStatus.UNKNOWN
+        if self.aggregate_price_info.price_status == PythPriceStatus.TRADING and \
+            slot - self.aggregate_price_info.pub_slot > MAX_SLOT_DIFFERENCE:
+            return PythPriceStatus.UNKNOWN
 
-            return self.aggregate_price_info.price_status
-        else:
-            return None
+        return self.aggregate_price_info.price_status
 
     def update_from(self, buffer: bytes, *, version: int, offset: int = 0) -> None:
         """

--- a/pythclient/pythaccounts.py
+++ b/pythclient/pythaccounts.py
@@ -8,7 +8,7 @@ import struct
 from loguru import logger
 
 from . import exceptions
-from .solana import SolanaCommitment, SolanaPublicKey, SolanaPublicKeyOrStr, SolanaClient, SolanaAccount
+from .solana import SolanaPublicKey, SolanaPublicKeyOrStr, SolanaClient, SolanaAccount
 
 
 _MAGIC = 0xA1B2C3D4
@@ -496,7 +496,7 @@ class PythPriceAccount(PythAccount):
     def aggregate_price(self) -> Optional[float]:
         """
         The aggregate price. Returns None if price is not currently available.
-        If you need the price value regardless of availability please use `aggregate_price_info.price`
+        If you need the price value regardless of availability use `aggregate_price_info.price`
         """
         if self.aggregate_price_status == PythPriceStatus.TRADING:
             return self.aggregate_price_info.price
@@ -507,7 +507,7 @@ class PythPriceAccount(PythAccount):
     def aggregate_price_confidence_interval(self) -> Optional[float]:
         """
         The aggregate price confidence interval. Returns None if price is not currently available.
-        If you need the confidence value regardless of availability please use `aggregate_price_info.confidence_interval`
+        If you need the confidence value regardless of availability use `aggregate_price_info.confidence_interval`
         """
         if self.aggregate_price_status == PythPriceStatus.TRADING:
             return self.aggregate_price_info.confidence_interval
@@ -522,7 +522,7 @@ class PythPriceAccount(PythAccount):
     def get_aggregate_price_status_with_slot(self, slot: int) -> Optional[PythPriceStatus]:
         """
         Gets the aggregate price status given a solana slot.
-        You might need to use it with the latest solana slot to make sure the price has not gone stale.
+        You might consider using this function with the latest solana slot to make sure the price has not gone stale.
         """
         if self.aggregate_price_info:
             if self.aggregate_price_info.price_status == PythPriceStatus.TRADING and \

--- a/pythclient/pythaccounts.py
+++ b/pythclient/pythaccounts.py
@@ -365,7 +365,7 @@ class PythPriceInfo:
         price (int): the price
         confidence_interval (int): the price confidence interval
         price_status (PythPriceStatus): the price status
-        slot (int): the slot time this price information was published
+        pub_slot (int): the slot time this price information was published
         exponent (int): the power-of-10 order of the price
     """
 
@@ -374,7 +374,7 @@ class PythPriceInfo:
     raw_price: int
     raw_confidence_interval: int
     price_status: PythPriceStatus
-    slot: int
+    pub_slot: int
     exponent: int
 
     price: float = field(init=False)
@@ -398,9 +398,9 @@ class PythPriceInfo:
             slot (u64)
         """
         # _ is corporate_action
-        price, confidence_interval, price_status, _, slot = struct.unpack_from(
+        price, confidence_interval, price_status, _, pub_slot = struct.unpack_from(
             "<qQIIQ", buffer, offset)
-        return PythPriceInfo(price, confidence_interval, PythPriceStatus(price_status), slot, exponent)
+        return PythPriceInfo(price, confidence_interval, PythPriceStatus(price_status), pub_slot, exponent)
 
     def __str__(self) -> str:
         return f"PythPriceInfo status {self.price_status} price {self.price}"
@@ -473,7 +473,7 @@ class PythPriceAccount(PythAccount):
         aggregate_price_info (PythPriceInfo): the aggregate price information
         price_components (List[PythPriceComponent]): the price components that the
             aggregate price is composed of
-        slot (int): the slot time when this account was last updated
+        slot (int): the slot time when this account was last fetched
         product (Optional[PythProductAccount]): the product this price is for, if loaded
     """
 
@@ -494,25 +494,44 @@ class PythPriceAccount(PythAccount):
 
     @property
     def aggregate_price(self) -> Optional[float]:
-        """the aggregate price"""
-        return self.aggregate_price_info and self.aggregate_price_info.price
+        """
+        The aggregate price. Returns None if price is not currently available.
+        If you need the price value regardless of availability please use `aggregate_price_info.price`
+        """
+        if self.aggregate_price_status == PythPriceStatus.TRADING:
+            return self.aggregate_price_info.price
+        else:
+            return None
 
     @property
     def aggregate_price_confidence_interval(self) -> Optional[float]:
-        """the aggregate price confidence interval"""
-        return self.aggregate_price_info and self.aggregate_price_info.confidence_interval
+        """
+        The aggregate price confidence interval. Returns None if price is not currently available.
+        If you need the confidence value regardless of availability please use `aggregate_price_info.confidence_interval`
+        """
+        if self.aggregate_price_status == PythPriceStatus.TRADING:
+            return self.aggregate_price_info.confidence_interval
+        else:
+            return None
+    
+    @property
+    def aggregate_price_status(self) -> Optional[PythPriceStatus]:
+        """The aggregate price status."""
+        return self.get_aggregate_price_status_with_slot(self.slot)
 
-    async def get_aggregate_price_status(self, commitment: str = SolanaCommitment.CONFIRMED) -> Optional[PythPriceStatus]:
-        """the aggregate price status"""
-
+    def get_aggregate_price_status_with_slot(self, slot: int) -> Optional[PythPriceStatus]:
+        """
+        Gets the aggregate price status given a solana slot.
+        You might need to use it with the latest solana slot to make sure the price has not gone stale.
+        """
         if self.aggregate_price_info:
-            current_slot = await self.solana.get_commitment_slot(commitment)
-
             if self.aggregate_price_info.price_status == PythPriceStatus.TRADING and \
-                current_slot - self.aggregate_price_info.slot > MAX_SLOT_DIFFERENCE:
+                slot - self.aggregate_price_info.pub_slot > MAX_SLOT_DIFFERENCE:
                 return PythPriceStatus.UNKNOWN
 
             return self.aggregate_price_info.price_status
+        else:
+            return None
 
     def update_from(self, buffer: bytes, *, version: int, offset: int = 0) -> None:
         """

--- a/pythclient/solana.py
+++ b/pythclient/solana.py
@@ -286,10 +286,10 @@ class SolanaClient:
     async def get_cluster_nodes(self) -> List[Dict[str, Any]]:
         return await self.http_send("getClusterNodes")
 
-    async def get_commitment_slot(
+    async def get_slot(
         self,
-        commitment: str
-        ) -> Dict[str, Any]:
+        commitment: str = SolanaCommitment.CONFIRMED,
+        ) -> Union[int, Dict[str, Any]]:
         return await self.http_send(
             "getSlot",
             [{"commitment": commitment}]

--- a/tests/test_price_account.py
+++ b/tests/test_price_account.py
@@ -1,9 +1,9 @@
-from unittest.mock import AsyncMock
 import pytest
 import base64
 from dataclasses import asdict
 
 from pytest_mock import MockerFixture
+from mock import AsyncMock
 
 from pythclient.pythaccounts import (
     MAX_SLOT_DIFFERENCE,

--- a/tests/test_price_component.py
+++ b/tests/test_price_component.py
@@ -21,14 +21,14 @@ def price_component() -> PythPriceComponent:
         'raw_price': 62931500000,
         'raw_confidence_interval': 16500000,
         'price_status': PythPriceStatus.TRADING,
-        'slot': 105886163,
+        'pub_slot': 105886163,
         'exponent': exponent,
     })
     latest_price = PythPriceInfo(**{
         'raw_price': 62931500000,
         'raw_confidence_interval': 16500000,
         'price_status': PythPriceStatus.TRADING,
-        'slot': 105886164,
+        'pub_slot': 105886164,
         'exponent': exponent,
     })
     return PythPriceComponent(

--- a/tests/test_price_info.py
+++ b/tests/test_price_info.py
@@ -10,7 +10,7 @@ def price_info_trading():
         raw_price=59609162000,
         raw_confidence_interval=43078500,
         price_status=PythPriceStatus.TRADING,
-        slot=105367617,
+        pub_slot=105367617,
         exponent=-8,
     )
 
@@ -21,7 +21,7 @@ def price_info_trading_bytes():
 
 
 @pytest.mark.parametrize(
-    "raw_price,raw_confidence_interval,price_status,slot,exponent,price,confidence_interval",
+    "raw_price,raw_confidence_interval,price_status,pub_slot,exponent,price,confidence_interval",
     [
         (
             1234567890,
@@ -42,7 +42,7 @@ class TestPythPriceInfo:
         raw_price,
         raw_confidence_interval,
         price_status,
-        slot,
+        pub_slot,
         exponent,
         price,
         confidence_interval,
@@ -51,7 +51,7 @@ class TestPythPriceInfo:
             raw_price=raw_price,
             raw_confidence_interval=raw_confidence_interval,
             price_status=price_status,
-            slot=slot,
+            pub_slot=pub_slot,
             exponent=exponent,
         )
         for key, actual_value in asdict(actual).items():
@@ -62,7 +62,7 @@ class TestPythPriceInfo:
         raw_price,
         raw_confidence_interval,
         price_status,
-        slot,
+        pub_slot,
         exponent,
         price,
         confidence_interval,
@@ -72,7 +72,7 @@ class TestPythPriceInfo:
                 raw_price=raw_price,
                 raw_confidence_interval=raw_confidence_interval,
                 price_status=price_status,
-                slot=slot,
+                pub_slot=pub_slot,
                 exponent=exponent,
             )
         )
@@ -80,7 +80,7 @@ class TestPythPriceInfo:
             "raw_price": raw_price,
             "raw_confidence_interval": raw_confidence_interval,
             "price_status": price_status,
-            "slot": slot,
+            "pub_slot": pub_slot,
             "exponent": exponent,
             "price": price,
             "confidence_interval": confidence_interval,


### PR DESCRIPTION
Adds`aggregate_price_status` property in Price Account which returns the aggregate price status considering the latest fetch slot to make sure price is not stale. `get_aggregate_price_status_with_slot` is also added so users can give latest solana slot for checking that price is not stale.

Additional Changes:
- Price Info `slot` field is renamed to `pub_slot`: `slot` is used in other objects within the pyth client with a different meaning (fetch slot). `pub_slot` is also consistent with other clients.
- `aggregate_price` and `aggregate_price_confidence_interval` will use status and return None if price is not available (status != trading). Comments have been added to guide how to get these values if needed regardless of availability. This is more consistent with our Rust client api and will prevent incautious users to rely on price if it's not available. 
- In solana module `get_commitment_slot` is renamed to `get_slot` to be more consistent with the rest of its interface. Also the return type is updated.
- Also fixes a small bug in dump example by indenting back the `break` on ws update handling logic.