### PR TITLE
support updating > 100 products

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.md', 'r', encoding='utf-8') as fh:
 
 setup(
     name='pythclient',
-    version='0.1.0',
+    version='0.1.1',
     packages=['pythclient'],
     author='Pyth Developers',
     author_email='contact@pyth.network',


### PR DESCRIPTION
with the recent addition of 30 equities in devnet/testnet, our total number of products are more than 100 and the sdk threw an error when trying to update more than > 100 products due to the limitations of solana's `getMultipleAccounts` rpc api (more info here: https://docs.solana.com/developing/clients/jsonrpc-api#getmultipleaccounts)

solution:
split the products to groups of 100 and run `update_products` with `grouped_products` each time