### PR TITLE
return timestamp and prev_timestamp

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.md', 'r', encoding='utf-8') as fh:
 
 setup(
     name='pythclient',
-    version='0.1.0',
+    version='0.1.2',
     packages=['pythclient'],
     author='Pyth Developers',
     author_email='contact@pyth.network',


### PR DESCRIPTION
I noticed that `prev_slot`, `prev_price`, and `prev_conf` weren't returned previously -- was there any particular reason for doing so? if not I can implement them in a separate PR

note: timestamp returned is unix timestamp in seconds