### PR TITLE
fix add_feed_ids bug

### DIFF
--- a/pythclient/hermes.py
+++ b/pythclient/hermes.py
@@ -47,9 +47,14 @@ class HermesClient:
         return data
 
     def add_feed_ids(self, feed_ids: list[str]):
-        self.feed_ids += feed_ids
-        self.feed_ids = list(set(self.feed_ids))
-        self.pending_feed_ids += feed_ids
+        # convert feed_ids to a set to remove any duplicates from the input
+        new_feed_ids_set = set(feed_ids)
+        
+        # update self.feed_ids; convert to set for union operation, then back to list
+        self.feed_ids = list(set(self.feed_ids).union(new_feed_ids_set))
+        
+        # update self.pending_feed_ids with only those IDs that are truly new
+        self.pending_feed_ids = list(set(self.pending_feed_ids).union(new_feed_ids_set))
 
     @staticmethod
     def extract_price_feed_v1(data: dict) -> PriceFeed:

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.md', 'r', encoding='utf-8') as fh:
 
 setup(
     name='pythclient',
-    version='0.1.23',
+    version='0.1.24',
     packages=['pythclient'],
     author='Pyth Developers',
     author_email='contact@pyth.network',

--- a/tests/test_hermes.py
+++ b/tests/test_hermes.py
@@ -125,7 +125,7 @@ async def test_hermes_add_feed_ids(hermes_client: HermesClient, mock_get_price_f
 
     assert len(set(hermes_client.feed_ids)) == len(hermes_client.feed_ids)
     assert set(hermes_client.feed_ids) == set(feed_ids_pre + feed_ids)
-    assert set(hermes_client.pending_feed_ids) == set(pending_feed_ids_pre + feed_ids)
+    assert len(hermes_client.pending_feed_ids) == len(set(pending_feed_ids_pre + feed_ids))
 
 def test_hermes_extract_price_feed_v1(hermes_client: HermesClient, data_v1: dict):
     price_feed = hermes_client.extract_price_feed_v1(data_v1)


### PR DESCRIPTION
there is a current duplicate bug with `add_feed_ids` where if you add multiple duplicate ids, `pending_feed_ids` will result in duplicate ids as explained here https://github.com/pyth-network/pyth-client-py/pull/54#discussion_r1496943091